### PR TITLE
MIC-501 remediations for Update Referral screens

### DIFF
--- a/server/routes/csip-records/components/proactive.njk
+++ b/server/routes/csip-records/components/proactive.njk
@@ -149,7 +149,7 @@
                 text: "Description of behaviour and concerns"
             },
             value: {
-                html: referral.descriptionOfConcern | escape | nl2br
+                html: referral.descriptionOfConcern | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [
@@ -167,7 +167,7 @@
                 text: "Reasons given for the behaviour"
             },
             value: {
-                html: referral.knownReasons | escape | nl2br
+                html: referral.knownReasons | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [

--- a/server/routes/csip-records/components/reactive.njk
+++ b/server/routes/csip-records/components/reactive.njk
@@ -172,7 +172,7 @@
             actions: {
                 items: [
                     {
-                        href: "reasons#knownReasons",
+                        href: "update-referral/reasons#knownReasons",
                         text: "Change",
                         visuallyHiddenText: "the reasons given for the incident",
                         classes: "govuk-link--no-visited-state"

--- a/server/routes/csip-records/components/reactive.njk
+++ b/server/routes/csip-records/components/reactive.njk
@@ -149,7 +149,7 @@
                 text: "Description of incident and concerns"
             },
             value: {
-                html: referral.descriptionOfConcern | escape | nl2br
+                html: referral.descriptionOfConcern | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [
@@ -167,7 +167,7 @@
                 text: "Reasons given for the incident"
             },
             value: {
-                html: referral.knownReasons | escape | nl2br
+                html: referral.knownReasons | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [

--- a/server/routes/csip-records/components/referral.njk
+++ b/server/routes/csip-records/components/referral.njk
@@ -117,7 +117,7 @@
                 text: 'Comment'
             },
             value: {
-                html: (factor.comment or 'Not provided') | escape | nl2br
+                html: (factor.comment or 'Not provided') | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [
@@ -173,7 +173,7 @@
                 text: "Other information relating to this referral"
             },
             value: {
-                html: (referral.otherInformation or 'Not provided') | escape | nl2br
+                html: (referral.otherInformation or 'Not provided') | escape | boldAppendStamp | nl2br
             },
             actions: {
                 items: [

--- a/server/routes/journeys/referral/additional-information/view.njk
+++ b/server/routes/journeys/referral/additional-information/view.njk
@@ -15,7 +15,7 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {% if isUpdate and currentOtherInformation %}
             {{ govukInsetText({
-                text: currentOtherInformation | escape | nl2br
+                html: currentOtherInformation | escape | boldAppendStamp | nl2br
             }) }}
         {% endif %}
         {{ govukCharacterCount({

--- a/server/routes/journeys/referral/additional-information/view.njk
+++ b/server/routes/journeys/referral/additional-information/view.njk
@@ -9,10 +9,15 @@
 {% block innerContent %}
     {% include 'base/components/referral-caption.njk' %}
     <label for="otherInformation">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Add additional information (optional)</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Add additional information{% if not isUpdate %} (optional){% endif %}</h1>
     </label>
     <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        {% if isUpdate and currentOtherInformation %}
+            {{ govukInsetText({
+                text: currentOtherInformation | escape | nl2br
+            }) }}
+        {% endif %}
         {{ govukCharacterCount({
             maxlength: maxLengthChars,
             rows: 5,
@@ -25,11 +30,6 @@
             },
             errorMessage: validationErrors | findError('otherInformation')
         }) }}
-        {% if isUpdate %}
-            {{ govukInsetText({
-                text: currentOtherInformation | escape | nl2br
-            }) }}
-        {% endif %}
         {{ submitButton({
             text: "Confirm and save" if isUpdate else "Continue",
             alternativeHyperlinkHref: isUpdate and ("/csip-records/" + recordUuid)

--- a/server/routes/journeys/referral/description/view.njk
+++ b/server/routes/journeys/referral/description/view.njk
@@ -36,7 +36,7 @@
             summaryText: "What type of information to include",
             html: detailsHtml
         }) }}
-        {% if isUpdate %}
+        {% if isUpdate and currentDescriptionOfConcern %}
             {{ govukInsetText({
                 text: currentDescriptionOfConcern | escape | nl2br
             }) }}

--- a/server/routes/journeys/referral/description/view.njk
+++ b/server/routes/journeys/referral/description/view.njk
@@ -38,7 +38,7 @@
         }) }}
         {% if isUpdate and currentDescriptionOfConcern %}
             {{ govukInsetText({
-                text: currentDescriptionOfConcern | escape | nl2br
+                html: currentDescriptionOfConcern | escape | boldAppendStamp | nl2br
             }) }}
         {% endif %}
         {{ govukCharacterCount({

--- a/server/routes/journeys/referral/reasons/view.njk
+++ b/server/routes/journeys/referral/reasons/view.njk
@@ -17,7 +17,7 @@
     </label>
     <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-         {% if isUpdate %}
+         {% if isUpdate and currentKnownReasons %}
             {{ govukInsetText({
                 text: currentKnownReasons | escape | nl2br
             }) }}

--- a/server/routes/journeys/referral/reasons/view.njk
+++ b/server/routes/journeys/referral/reasons/view.njk
@@ -19,7 +19,7 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
          {% if isUpdate and currentKnownReasons %}
             {{ govukInsetText({
-                text: currentKnownReasons | escape | nl2br
+                html: currentKnownReasons | escape | boldAppendStamp | nl2br
             }) }}
         {% endif %}
         {{ govukCharacterCount({

--- a/server/routes/journeys/update-referral/additional-information/tests.cy.ts
+++ b/server/routes/journeys/update-referral/additional-information/tests.cy.ts
@@ -1,7 +1,7 @@
 import { generateSaveTimestamp } from '../../../../utils/appendFieldUtils'
 
 context('test /update-referral/additional-information', () => {
-  const title = /Add additional information \(optional\)/i
+  const title = /Add additional information/i
   const errorMsg = /enter an update to the additional information/i
   const dividerText = generateSaveTimestamp('John Smith')
   const totalUsedChars = dividerText.length + 170 // 170 = already existing additional info text

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
 import fs from 'fs'
-import { convertToTitleCase, initialiseName, sentenceCase } from './utils'
+import { boldAppendStamp, convertToTitleCase, initialiseName, sentenceCase } from './utils'
 import config from '../config'
 import { buildErrorSummaryList, customErrorOrderBuilder, findError } from '../middleware/validationMiddleware'
 import { formatDisplayDate, todayStringGBFormat } from './datetimeUtils'
@@ -66,6 +66,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('customErrorOrderBuilder', customErrorOrderBuilder)
   njkEnv.addFilter('firstNameSpaceLastName', firstNameSpaceLastName)
   njkEnv.addFilter('possessiveComma', (name: string) => (name.endsWith('s') ? `${name}’` : `${name}’s`))
+  njkEnv.addFilter('boldAppendStamp', boldAppendStamp)
   njkEnv.addFilter('csipStatusDisplayText', csipStatusDisplayText)
   njkEnv.addFilter('csipStatusTagClass', csipStatusTagClass)
   njkEnv.addGlobal('todayStringGBFormat', todayStringGBFormat)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -67,3 +67,24 @@ export const ordinalNumber = (number: number) => {
   const ordinal = ['st', 'nd', 'rd'][((((number + 90) % 100) - 10) % 10) - 1] || 'th'
   return number + ordinal
 }
+
+const APPEND_STAMP_REGEX = /\n(\[.+?])\n/g
+
+export const boldAppendStamp = (val: string) => {
+  const res: string[] = []
+  let endIndex = 0
+
+  val.matchAll(APPEND_STAMP_REGEX).forEach(match => {
+    if (match.index > 0) {
+      res.push(val.substring(endIndex, match.index))
+    }
+    res.push('\n<strong>')
+    res.push(match[1]!)
+    res.push('</strong>\n')
+    endIndex = match.index + match[0].length
+  })
+
+  res.push(val.substring(endIndex))
+
+  return res.join('')
+}


### PR DESCRIPTION
set bold style to append stamp (by matching `\n[ text ]\n`, hence the new filter needs to go before nl2br)
![image](https://github.com/user-attachments/assets/1be3d3c4-cc12-458e-b7f6-425000d4200a)

UaR update additional information screen title fix (remove `(optional)`)
![image](https://github.com/user-attachments/assets/a5ffacc6-5a2a-4d4b-a976-cb3bcc1c04f5)

when additional information value is null, don't show the inset text component:
![image](https://github.com/user-attachments/assets/871a3eb6-9dc5-40fb-8f66-1797138840ff)
