### PR TITLE
UI remediations for Update-Investigation

### DIFF
--- a/server/routes/csip-records/controller.ts
+++ b/server/routes/csip-records/controller.ts
@@ -164,6 +164,7 @@ export class CsipRecordController {
 
     res.render('csip-records/view', {
       status: record.status,
+      updatingEntity: record.plan ? null : 'referral',
       shouldShowTabs: hasInvestigation(record.status),
       record,
       decision,

--- a/server/routes/csip-records/view.njk
+++ b/server/routes/csip-records/view.njk
@@ -23,7 +23,7 @@
   {% endset %}
 {% endif %}
 
-{% set basePageHeader = 'CSIP ' + (updatingEntity + ' ') if updatingEntity else '' + 'for ' + (prisoner | firstNameSpaceLastName) %}
+{% set basePageHeader = 'CSIP ' + (updatingEntity + ' ' if updatingEntity else '') + 'for ' + (prisoner | firstNameSpaceLastName) %}
 
 {% block pageHeader %}
   {% if successMessage %}

--- a/server/routes/csip-records/view.njk
+++ b/server/routes/csip-records/view.njk
@@ -23,7 +23,7 @@
   {% endset %}
 {% endif %}
 
-{% set basePageHeader = 'CSIP ' + updatingEntity + ' for ' + (prisoner | firstNameSpaceLastName) %}
+{% set basePageHeader = 'CSIP ' + (updatingEntity + ' ') if updatingEntity else '' + 'for ' + (prisoner | firstNameSpaceLastName) %}
 
 {% block pageHeader %}
   {% if successMessage %}

--- a/server/routes/journeys/develop-an-initial-plan/controller.ts
+++ b/server/routes/journeys/develop-an-initial-plan/controller.ts
@@ -10,8 +10,8 @@ export class DevelopPlanController {
         : res.locals.formResponses?.['isCaseManager'] === 'true'
 
     const isCaseManager = formResponseIsCaseManager ?? req.journeyData.plan!.isCaseManager
-    const caseManager = res.locals.formResponses?.['caseManager'] || req.journeyData.plan!.caseManager
-    const reasonForPlan = res.locals.formResponses?.['reasonForPlan'] || req.journeyData.plan!.reasonForPlan
+    const caseManager = res.locals.formResponses?.['caseManager'] ?? req.journeyData.plan!.caseManager
+    const reasonForPlan = res.locals.formResponses?.['reasonForPlan'] ?? req.journeyData.plan!.reasonForPlan
 
     res.render('develop-an-initial-plan/view', { isCaseManager, caseManager, reasonForPlan })
   }

--- a/server/routes/journeys/record-decision/additional-information/controller.ts
+++ b/server/routes/journeys/record-decision/additional-information/controller.ts
@@ -3,7 +3,7 @@ import { SchemaType } from './schemas'
 
 export class DecisionAdditionalInformationController {
   GET = async (req: Request, res: Response) => {
-    const actionOther = res.locals.formResponses?.['actionOther'] || req.journeyData.decisionAndActions!.actionOther
+    const actionOther = res.locals.formResponses?.['actionOther'] ?? req.journeyData.decisionAndActions!.actionOther
     res.render('record-decision/additional-information/view', {
       actionOther,
       backUrl: 'next-steps',

--- a/server/routes/journeys/record-decision/conclusion/controller.ts
+++ b/server/routes/journeys/record-decision/conclusion/controller.ts
@@ -7,11 +7,11 @@ export class ConclusionController extends BaseJourneyController {
     const outcomeTypeOptions = await this.getReferenceDataOptionsForRadios(
       req,
       'decision-outcome-type',
-      res.locals.formResponses?.['outcome'] || req.journeyData.decisionAndActions!.outcome,
+      res.locals.formResponses?.['outcome'] ?? req.journeyData.decisionAndActions!.outcome,
     )
 
     res.render('record-decision/conclusion/view', {
-      conclusion: res.locals.formResponses?.['conclusion'] || req.journeyData.decisionAndActions?.conclusion,
+      conclusion: res.locals.formResponses?.['conclusion'] ?? req.journeyData.decisionAndActions?.conclusion,
       outcomeTypeOptions,
       backUrl: '../record-decision',
     })

--- a/server/routes/journeys/record-decision/controller.ts
+++ b/server/routes/journeys/record-decision/controller.ts
@@ -7,7 +7,7 @@ export class RecordDecisionController extends BaseJourneyController {
     const signedOffByRoleOptions = await this.getReferenceDataOptionsForRadios(
       req,
       'role',
-      res.locals.formResponses?.['signedOffByRole'] || req.journeyData.decisionAndActions!.signedOffByRole,
+      res.locals.formResponses?.['signedOffByRole'] ?? req.journeyData.decisionAndActions!.signedOffByRole,
     )
 
     res.render('record-decision/view', { signedOffByRoleOptions })

--- a/server/routes/journeys/record-decision/next-steps/controller.ts
+++ b/server/routes/journeys/record-decision/next-steps/controller.ts
@@ -3,7 +3,7 @@ import { SchemaType } from './schemas'
 
 export class NextStepsController {
   GET = async (req: Request, res: Response) => {
-    const nextSteps = res.locals.formResponses?.['nextSteps'] || req.journeyData.decisionAndActions!.nextSteps
+    const nextSteps = res.locals.formResponses?.['nextSteps'] ?? req.journeyData.decisionAndActions!.nextSteps
     res.render('record-decision/next-steps/view', {
       nextSteps,
       backUrl: 'conclusion',

--- a/server/routes/journeys/record-investigation/evidence-secured/controller.ts
+++ b/server/routes/journeys/record-investigation/evidence-secured/controller.ts
@@ -4,7 +4,7 @@ import { SchemaType } from './schemas'
 export class EvidenceSecuredController {
   GET = async (req: Request, res: Response) => {
     const evidenceSecured =
-      res.locals.formResponses?.['evidenceSecured'] || req.journeyData.investigation?.evidenceSecured
+      res.locals.formResponses?.['evidenceSecured'] ?? req.journeyData.investigation?.evidenceSecured
     res.render('record-investigation/evidence-secured/view', {
       evidenceSecured,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/record-investigation/protective-factors/controller.ts
+++ b/server/routes/journeys/record-investigation/protective-factors/controller.ts
@@ -4,7 +4,7 @@ import { SchemaType } from './schemas'
 export class ProtectiveFactorsController {
   GET = async (req: Request, res: Response) => {
     const protectiveFactors =
-      res.locals.formResponses?.['protectiveFactors'] || req.journeyData.investigation?.protectiveFactors
+      res.locals.formResponses?.['protectiveFactors'] ?? req.journeyData.investigation?.protectiveFactors
     res.render('record-investigation/protective-factors/view', {
       protectiveFactors,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/record-investigation/staff-involved/controller.ts
+++ b/server/routes/journeys/record-investigation/staff-involved/controller.ts
@@ -3,7 +3,7 @@ import { SchemaType } from './schemas'
 
 export class StaffInvolvedController {
   GET = async (req: Request, res: Response) => {
-    const staffInvolved = res.locals.formResponses?.['staffInvolved'] || req.journeyData.investigation!.staffInvolved
+    const staffInvolved = res.locals.formResponses?.['staffInvolved'] ?? req.journeyData.investigation!.staffInvolved
     res.render('record-investigation/staff-involved/view', {
       staffInvolved,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/record-investigation/triggers/controller.ts
+++ b/server/routes/journeys/record-investigation/triggers/controller.ts
@@ -3,7 +3,7 @@ import { SchemaType } from './schemas'
 
 export class TriggersController {
   GET = async (req: Request, res: Response) => {
-    const personsTrigger = res.locals.formResponses?.['personsTrigger'] || req.journeyData.investigation?.personsTrigger
+    const personsTrigger = res.locals.formResponses?.['personsTrigger'] ?? req.journeyData.investigation?.personsTrigger
     res.render('record-investigation/triggers/view', {
       personsTrigger,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/record-investigation/usual-behaviour-presentation/controller.ts
+++ b/server/routes/journeys/record-investigation/usual-behaviour-presentation/controller.ts
@@ -4,7 +4,7 @@ import { SchemaType } from './schemas'
 export class UsualBehaviourPresentationController {
   GET = async (req: Request, res: Response) => {
     const personsUsualBehaviour =
-      res.locals.formResponses?.['personsUsualBehaviour'] || req.journeyData.investigation?.personsUsualBehaviour
+      res.locals.formResponses?.['personsUsualBehaviour'] ?? req.journeyData.investigation?.personsUsualBehaviour
     res.render('record-investigation/usual-behaviour-presentation/view', {
       personsUsualBehaviour,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/record-investigation/why-behaviour-occurred/controller.ts
+++ b/server/routes/journeys/record-investigation/why-behaviour-occurred/controller.ts
@@ -4,7 +4,7 @@ import { SchemaType } from './schemas'
 export class OccurrenceReasonController {
   GET = async (req: Request, res: Response) => {
     const occurrenceReason =
-      res.locals.formResponses?.['occurrenceReason'] || req.journeyData.investigation!.occurrenceReason
+      res.locals.formResponses?.['occurrenceReason'] ?? req.journeyData.investigation!.occurrenceReason
     res.render('record-investigation/why-behaviour-occurred/view', {
       occurrenceReason,
       backUrl: '../record-investigation',

--- a/server/routes/journeys/referral/additional-information/controller.ts
+++ b/server/routes/journeys/referral/additional-information/controller.ts
@@ -4,7 +4,7 @@ import { SchemaType } from './schemas'
 export class ReferralAdditionalInformationController {
   GET = async (req: Request, res: Response) => {
     const otherInformation =
-      res.locals.formResponses?.['otherInformation'] || req.journeyData.referral!.otherInformation
+      res.locals.formResponses?.['otherInformation'] ?? req.journeyData.referral!.otherInformation
     res.render('referral/additional-information/view', {
       otherInformation,
       backUrl: 'safer-custody',

--- a/server/routes/journeys/referral/area-of-work/controller.ts
+++ b/server/routes/journeys/referral/area-of-work/controller.ts
@@ -8,7 +8,7 @@ export class ReferralAreaOfWorkController extends BaseJourneyController {
       req,
       'area-of-work',
       'Select area',
-      res.locals.formResponses?.['refererArea'] || req.journeyData.referral!.refererArea,
+      res.locals.formResponses?.['refererArea'] ?? req.journeyData.referral!.refererArea,
     )
     const backUrl =
       req.journeyData.isCheckAnswers && !req.journeyData.referral!.onBehalfOfSubJourney

--- a/server/routes/journeys/referral/description/controller.ts
+++ b/server/routes/journeys/referral/description/controller.ts
@@ -6,7 +6,7 @@ export class ReferralDescriptionController {
     res.render('referral/description/view', {
       isProactiveReferral: req.journeyData.referral!.isProactiveReferral,
       descriptionOfConcern:
-        res.locals.formResponses?.['descriptionOfConcern'] || req.journeyData.referral!.descriptionOfConcern,
+        res.locals.formResponses?.['descriptionOfConcern'] ?? req.journeyData.referral!.descriptionOfConcern,
       backUrl: 'involvement',
       maxLengthChars: 4000,
       threshold: '75',

--- a/server/routes/journeys/referral/reasons/controller.ts
+++ b/server/routes/journeys/referral/reasons/controller.ts
@@ -5,7 +5,7 @@ export class ReferralReasonsController {
   GET = async (req: Request, res: Response) => {
     res.render('referral/reasons/view', {
       isProactiveReferral: req.journeyData.referral!.isProactiveReferral,
-      knownReasons: res.locals.formResponses?.['knownReasons'] || req.journeyData.referral!.knownReasons,
+      knownReasons: res.locals.formResponses?.['knownReasons'] ?? req.journeyData.referral!.knownReasons,
       backUrl: 'description',
     })
   }

--- a/server/routes/journeys/referral/referrer/controller.ts
+++ b/server/routes/journeys/referral/referrer/controller.ts
@@ -8,7 +8,7 @@ export class ReferralReferrerController extends BaseJourneyController {
       req,
       'area-of-work',
       'Select area',
-      res.locals.formResponses?.['areaOfWork'] || req.journeyData.referral!.refererArea,
+      res.locals.formResponses?.['areaOfWork'] ?? req.journeyData.referral!.refererArea,
     )
 
     const backUrl =

--- a/server/routes/journeys/screen/controller.ts
+++ b/server/routes/journeys/screen/controller.ts
@@ -7,13 +7,13 @@ export class ScreenController extends BaseJourneyController {
     const outcomeTypeItems = await this.getReferenceDataOptionsForRadios(
       req,
       'screening-outcome-type',
-      res.locals.formResponses?.['outcomeType'] || req.journeyData.saferCustodyScreening?.outcomeType,
+      res.locals.formResponses?.['outcomeType'] ?? req.journeyData.saferCustodyScreening?.outcomeType,
     )
 
     res.render('screen/view', {
       outcomeTypeItems,
       reasonForDecision:
-        res.locals.formResponses?.['reasonForDecision'] || req.journeyData.saferCustodyScreening?.reasonForDecision,
+        res.locals.formResponses?.['reasonForDecision'] ?? req.journeyData.saferCustodyScreening?.reasonForDecision,
     })
   }
 

--- a/server/routes/journeys/update-investigation/protective-factors/controller.ts
+++ b/server/routes/journeys/update-investigation/protective-factors/controller.ts
@@ -10,6 +10,7 @@ export class UpdateProtectiveFactorsController extends PatchInvestigationControl
       currentProtectiveFactors,
       protectiveFactors: res.locals.formResponses?.['protectiveFactors'],
       isUpdate: true,
+      backUrl: '../update-investigation',
       recordUuid: req.journeyData.csipRecord!.recordUuid,
       ...getMaxCharsAndThresholdForAppend(res.locals.user.displayName, currentProtectiveFactors),
     })

--- a/server/routes/journeys/update-investigation/triggers/controller.ts
+++ b/server/routes/journeys/update-investigation/triggers/controller.ts
@@ -10,6 +10,7 @@ export class UpdateTriggersController extends PatchInvestigationController {
       currentPersonsTrigger,
       personsTrigger: res.locals.formResponses?.['personsTrigger'],
       isUpdate: true,
+      backUrl: '../update-investigation',
       recordUuid: req.journeyData.csipRecord!.recordUuid,
       ...getMaxCharsAndThresholdForAppend(res.locals.user.displayName, currentPersonsTrigger),
     })

--- a/server/routes/journeys/update-investigation/usual-behaviour-presentation/controller.ts
+++ b/server/routes/journeys/update-investigation/usual-behaviour-presentation/controller.ts
@@ -10,6 +10,7 @@ export class UpdateUsualBehaviourController extends PatchInvestigationController
       currentPersonsUsualBehaviour,
       personsUsualBehaviour: res.locals.formResponses?.['personsUsualBehaviour'],
       isUpdate: true,
+      backUrl: '../update-investigation',
       recordUuid: req.journeyData.csipRecord!.recordUuid,
       ...getMaxCharsAndThresholdForAppend(res.locals.user.displayName, currentPersonsUsualBehaviour),
     })

--- a/server/routes/journeys/update-investigation/why-behaviour-occurred/controller.ts
+++ b/server/routes/journeys/update-investigation/why-behaviour-occurred/controller.ts
@@ -10,6 +10,7 @@ export class UpdateWhyBehaviourOccurredController extends PatchInvestigationCont
       currentOccurrenceReason,
       occurrenceReason: res.locals.formResponses?.['occurrenceReason'],
       isUpdate: true,
+      backUrl: '../update-investigation',
       recordUuid: req.journeyData.csipRecord!.recordUuid,
       ...getMaxCharsAndThresholdForAppend(res.locals.user.displayName, currentOccurrenceReason),
     })

--- a/server/routes/journeys/update-referral/new-contributory-factor-comment/controller.ts
+++ b/server/routes/journeys/update-referral/new-contributory-factor-comment/controller.ts
@@ -8,7 +8,7 @@ export class NewContributoryFactorCommentController extends BaseJourneyControlle
   GET = async (req: Request, res: Response) => {
     res.render('referral/contributory-factor-comment/view', {
       factorDescription: req.journeyData.referral!.contributoryFactorSubJourney!.factorType!.description,
-      comment: res.locals.formResponses?.['comment'] || req.journeyData.referral!.contributoryFactorSubJourney!.comment,
+      comment: res.locals.formResponses?.['comment'] ?? req.journeyData.referral!.contributoryFactorSubJourney!.comment,
       backUrl: 'add-contributory-factor',
       isUpdate: true,
       recordUuid: req.journeyData.csipRecord!.recordUuid,

--- a/server/routes/journeys/update-referral/referrer/controller.ts
+++ b/server/routes/journeys/update-referral/referrer/controller.ts
@@ -8,7 +8,7 @@ export class UpdateReferrerController extends PatchReferralController {
       req,
       'area-of-work',
       'Select area',
-      res.locals.formResponses?.['areaOfWork'] || req.journeyData.csipRecord!.referral.refererArea,
+      res.locals.formResponses?.['areaOfWork'] ?? req.journeyData.csipRecord!.referral.refererArea,
     )
 
     res.render('referral/referrer/view', {


### PR DESCRIPTION
1. add back url for update-investigation question screens
2. update controller to read formResponse or journeyData with `??` operator instead of `||`
3. fix heading of `/csip-records/:recordUuid` screen