### PR TITLE
MIAD-356: Related information is not announced when input field is focussed

### DIFF
--- a/server/routes/journeys/update-plan/planned-intervention/tests.cy.ts
+++ b/server/routes/journeys/update-plan/planned-intervention/tests.cy.ts
@@ -56,6 +56,29 @@ context('test /update-planned-intervention/:uuid', () => {
     )
   })
 
+  it('should not include inset text when no existing intervention details', () => {
+    cy.task('stubPatchIdentifiedNeedSuccess')
+    navigateToTestPage()
+    injectJourneyDataAndReload(uuid, {
+      plan: {
+        identifiedNeeds: [
+          {
+            identifiedNeed: 'first need',
+            responsiblePerson: 'test testerson',
+            createdDate: '2024-03-01',
+            targetDate: '2024-04-02',
+            intervention: '',
+            progression: 'progression done',
+            identifiedNeedUuid: 'a0000000-f7b1-4c56-bec8-69e390eb0003',
+          } as IdentifiedNeed,
+        ],
+      },
+    })
+    cy.url().should('to.match', /\/update-planned-intervention\/[a-zA-Z0-9-]+$/)
+    cy.get('.govuk-inset-text').should('have.length', 0)
+    cy.get('#intervention').should('have.attr', 'aria-describedby', 'intervention-info')
+  })
+
   it('should handle API errors', () => {
     cy.task('stubPatchIdentifiedNeedFail')
     navigateToTestPage()
@@ -79,6 +102,8 @@ context('test /update-planned-intervention/:uuid', () => {
   const validatePageContents = () => {
     cy.title().should('equal', 'Add information to the planned intervention - Update plan - DPS')
     cy.findByRole('heading', { name: 'Add information to the planned intervention' }).should('be.visible')
+    cy.get('.govuk-inset-text').should('be.visible')
+    cy.get('#intervention').should('have.attr', 'aria-describedby', 'intervention-info intervention-hint')
     getContinueButton().should('be.visible')
     cy.findByRole('link', { name: /Cancel/i })
       .should('be.visible')

--- a/server/routes/journeys/update-plan/planned-intervention/view.njk
+++ b/server/routes/journeys/update-plan/planned-intervention/view.njk
@@ -2,38 +2,34 @@
 {% from "partials/submitButton/macro.njk" import submitButton %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-
 {% extends "partials/layout.njk" %}
 
 {% set pageTitle = "Add information to the planned intervention - Update plan" %}
 
 {% block innerContent %}
-    {% include 'base/components/plan-caption.njk' %}
-    <label for="intervention">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{'Add information to the planned intervention'}}</h1>
-    </label>
-    <form method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+  {% include 'base/components/plan-caption.njk' %}
+  <label for="intervention">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{'Add information to the planned intervention'}}</h1>
+  </label>
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {% if currentIntervention %}
-            {{ govukInsetText({
-                html: currentIntervention | escape | boldAppendStamp | nl2br
-        }) }}
-        {% endif %}
+    {{ govukCharacterCount({
+      maxlength: maxLengthChars,
+      rows: 5,
+      threshold: threshold,
+      id: "intervention",
+      name: "intervention",
+      value: intervention,
+      errorMessage: validationErrors | findError('intervention'),
+      hint: {
+        html: '<div class="govuk-inset-text">' + (currentIntervention | escape | boldAppendStamp | nl2br) + '</div>'
+      } if currentIntervention else undefined
+    }) }}
 
-        {{ govukCharacterCount({
-            maxlength: maxLengthChars,
-            rows: 5,
-            threshold: threshold,
-            id: "intervention",
-            name: "intervention",
-            value: intervention,
-            errorMessage: validationErrors | findError('intervention')
-        }) }}
-
-        {{ submitButton({
-            text: "Confirm and save",
-            alternativeHyperlinkHref: "/csip-records/" + recordUuid
-        }) }}
-    </form>
+    {{ submitButton({
+      text: "Confirm and save",
+      alternativeHyperlinkHref: "/csip-records/" + recordUuid
+    }) }}
+  </form>
 {% endblock %}


### PR DESCRIPTION
GovukCharacterCount locks down `aria-describedby` so its non-trivial to just add a custom value to this, however since it passes the title element's id and the hint element's id (if set), we can move the inset text element inside the hint to achieve the same effect