### PR TITLE
MIA-606: Use aria-live to callout conditional content

### DIFF
--- a/server/routes/journeys/develop-an-initial-plan/tests.cy.ts
+++ b/server/routes/journeys/develop-an-initial-plan/tests.cy.ts
@@ -34,6 +34,24 @@ context('test /develop-an-initial-plan', () => {
     validateOptionalInput()
   })
 
+  it('should use screen reader callouts', () => {
+    navigateToTestPage()
+    cy.url().should('to.match', /\/develop-an-initial-plan$/)
+    validateScreenReaderCallout()
+  })
+
+  const validateScreenReaderCallout = () => {
+    cy.get('#caseManager-announce')
+      .should('have.attr', 'aria-live', 'polite')
+      .should('have.class', 'govuk-visually-hidden')
+      .children()
+      .should('have.length', 0)
+
+    getIsNotCaseManagerRadio().click()
+    cy.get('#caseManager-announce').children().should('have.length', 1)
+    cy.get('#caseManager-announce').children().eq(0).should('contain.text', 'Provide their name')
+  }
+
   const navigateToTestPage = () => {
     cy.signIn()
     cy.visit(`${uuid}/csip-record/02e5854f-f7b1-4c56-bec8-69e390eb8550/develop-an-initial-plan/start`)

--- a/server/routes/journeys/develop-an-initial-plan/view.njk
+++ b/server/routes/journeys/develop-an-initial-plan/view.njk
@@ -11,6 +11,8 @@
     <span class="govuk-caption-l">Develop an initial plan</span>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Case management</h1>
 
+    <div class="govuk-visually-hidden" id="caseManager-announce" aria-live="polite"></div>
+
     {% set caseManagerHtml %}
         {{ govukCharacterCount({
             label: { text: "Name of Case Manager" },
@@ -23,6 +25,7 @@
             value: caseManager,
             errorMessage: validationErrors | findError('caseManager')
         }) }}
+
     {% endset %}
 
     {% set caseManagerTitle %}
@@ -47,8 +50,8 @@
                     text: "No",
                     checked: isCaseManager === false,
                     conditional: {
-                    html: caseManagerHtml
-                }
+                        html: caseManagerHtml
+                    }
                 }
             ],
             errorMessage: validationErrors | findError('isCaseManager')
@@ -73,4 +76,19 @@
             preventDoubleClick: true
         }) }}
     </form>
+{% endblock %}
+
+{% block additionalScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+        const caseManagerNo = document.querySelector('#isCaseManager-2')
+        const srAnnounce = document.querySelector('#caseManager-announce')
+        
+        caseManagerNo?.addEventListener('change', () => {           
+            if (caseManagerNo?.checked) {
+                const newElement = document.createElement('span')
+                newElement.innerText = 'Provide their name'
+                srAnnounce.appendChild(newElement)
+            }
+        })
+    </script>
 {% endblock %}

--- a/server/routes/journeys/referral/involvement/tests.cy.ts
+++ b/server/routes/journeys/referral/involvement/tests.cy.ts
@@ -18,8 +18,13 @@ context('Make a Referral Journey', () => {
     cy.task('stubCsipRecordPostSuccess')
   })
 
+  it('should use screen reader callouts', () => {
+    navigateToTestPage()
+    validateScreenReaderCallout()
+  })
+
   it('test involvement, including all edge cases', () => {
-    setupDataSignInAndGo()
+    navigateToTestPage()
 
     checkProactiveReactiveContent()
 
@@ -31,6 +36,18 @@ context('Make a Referral Journey', () => {
 
     checkEmptyInputNotOverriddenByJourneyData()
   })
+
+  const validateScreenReaderCallout = () => {
+    cy.get('#assaultedStaffName-announce')
+      .should('have.attr', 'aria-live', 'polite')
+      .should('have.class', 'govuk-visually-hidden')
+      .children()
+      .should('have.length', 0)
+
+    cy.get('#isStaffAssaulted').click()
+    cy.get('#assaultedStaffName-announce').children().should('have.length', 1)
+    cy.get('#assaultedStaffName-announce').children().eq(0).should('contain.text', 'Provide their name')
+  }
 
   const goBackCheckValuesSaved = () => {
     cy.findByRole('textbox', { name: /names of staff assaulted/i }).type('staff stafferson', { delay: 0 })
@@ -157,7 +174,7 @@ context('Make a Referral Journey', () => {
     checkAxeAccessibility()
   }
 
-  const setupDataSignInAndGo = () => {
+  const navigateToTestPage = () => {
     cy.signIn()
     cy.visit('/prisoners/A1111AA/referral/start')
     injectJourneyDataAndReload(uuid, {

--- a/server/routes/journeys/referral/involvement/view.njk
+++ b/server/routes/journeys/referral/involvement/view.njk
@@ -10,7 +10,7 @@
 {% block content %}
     {% include 'base/components/referral-caption.njk' %}
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ "Behaviour involvement" if isProactiveReferral else "Incident involvement" }}</h1>
-
+    <div class="govuk-visually-hidden" id="assaultedStaffName-announce" aria-live="polite"></div>
     <form method="post">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
@@ -69,4 +69,19 @@
           alternativeHyperlinkHref: isUpdate and ("/csip-records/" + recordUuid)
       }) }}
     </form>
+{% endblock %}
+
+{% block additionalScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+        const assaultedStaffYes = document.querySelector('#isStaffAssaulted')
+        const srAnnounce = document.querySelector('#assaultedStaffName-announce')
+        
+        assaultedStaffYes?.addEventListener('change', () => {           
+            if (assaultedStaffYes?.checked) {
+              const newElement = document.createElement('span')
+              newElement.innerText = 'Provide their names'
+              srAnnounce.appendChild(newElement)
+            }
+        })
+    </script>
 {% endblock %}


### PR DESCRIPTION
Conditional content announces itself to screen readers when it appears using `aria-live`. No visible changes are made

![Kapture 2025-06-05 at 16 06 32](https://github.com/user-attachments/assets/24a6f10b-72fe-47d4-9dcf-b59a5a236601)
