### PR TITLE
Run integration tests in parallel again

### DIFF
--- a/.github/scripts/split-cypress-specs.mjs
+++ b/.github/scripts/split-cypress-specs.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const usage = 'Usage: split-cypress-specs.mjs <split-total> <split-index>'
+const splitTotal = Number.parseInt(process.argv[2] || '', 10)
+const splitIndex = Number.parseInt(process.argv[3] || '', 10)
+
+if (!Number.isInteger(splitTotal) || splitTotal < 1 || !Number.isInteger(splitIndex) || splitIndex < 0) {
+  throw new Error(usage)
+}
+
+if (splitIndex >= splitTotal) {
+  throw new Error(`split-index must be less than split-total. ${usage}`)
+}
+
+const ignoredDirectories = new Set(['.git', 'coverage', 'dist', 'node_modules', 'test_results'])
+const specPattern = /\.cy\.(js|jsx|ts|tsx)$/
+
+function findSpecs(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const absolutePath = path.join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return ignoredDirectories.has(entry.name) ? [] : findSpecs(absolutePath)
+    }
+
+    if (!entry.isFile() || !specPattern.test(entry.name)) {
+      return []
+    }
+
+    return path.relative(process.cwd(), absolutePath)
+  })
+}
+
+const specs = findSpecs(process.cwd()).sort((left, right) => left.localeCompare(right))
+const selectedSpecs = specs.filter((_, index) => index % splitTotal === splitIndex)
+const specList = selectedSpecs.join(',')
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `specs=${specList}\n`)
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `spec_count=${selectedSpecs.length}\n`)
+}
+
+process.stdout.write(`${specList}\n`)

--- a/.github/workflows/parallel_integration_tests.yml
+++ b/.github/workflows/parallel_integration_tests.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Get wiremock
         shell: bash
         run: |
-          curl -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+          WIREMOCK_VERSION="3.9.2"
+          WIREMOCK_SHA256="77b88dc41c3268e3ce391f3fef222b0cd0696f286d3fc35a84ba22ffcb877012"
+          curl --fail --location --show-error --output wiremock.jar "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar"
+          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum --check
       - name: Determine test split
         id: split-tests
         shell: bash

--- a/.github/workflows/parallel_integration_tests.yml
+++ b/.github/workflows/parallel_integration_tests.yml
@@ -1,0 +1,76 @@
+name: Parallel integration tests
+
+on:
+  workflow_call:
+    inputs:
+      node_version_file:
+        description: 'Passed to setup-node action to specify where to source the version of node from'
+        required: false
+        type: string
+        default: '.nvmrc'
+
+permissions:
+  contents: read
+
+jobs:
+  integration_test:
+    name: Run the integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Use Node.js ${{ inputs.node_version_file }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ${{ inputs.node_version_file }}
+      - name: download artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: npm_build_artifacts
+      - name: restore cache
+        id: restore-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        env:
+          cache-name: node-modules
+        with:
+          path: |
+            ./node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Get wiremock
+        shell: bash
+        run: |
+          curl -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+      - name: Determine test split
+        id: split-tests
+        shell: bash
+        run: |
+          node .github/scripts/split-cypress-specs.mjs "${{ strategy.job-total }}" "${{ strategy.job-index }}"
+      - name: Prepare and run integration tests
+        id: integration-tests
+        shell: bash
+        run: |
+          nohup java -jar wiremock.jar --port 9091 &
+          nohup npm run start-feature &
+          sleep 5
+          INT_TEST_RUN_ARGS="--spec ${{ steps.split-tests.outputs.specs }}" npm run int-test
+      - name: upload results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: npm_integration_test_artifacts_${{ matrix.shard }}
+          path: |
+            integration_tests/videos/
+            integration_tests/screenshots/
+            coverage/
+            test_results/
+            ctrf/
+      - name: fail the action if the tests failed
+        if: ${{ steps.integration-tests.outcome == 'failure' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            core.setFailed('Integration tests failed')

--- a/.github/workflows/parallel_integration_tests.yml
+++ b/.github/workflows/parallel_integration_tests.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 jobs:
-  integration_test:
-    name: Run the integration tests
+  integration_test_shard:
+    name: integration_test shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -74,3 +74,12 @@ jobs:
         with:
           script: |
             core.setFailed('Integration tests failed')
+
+  integration_test:
+    name: integration_test
+    runs-on: ubuntu-latest
+    needs:
+      - integration_test_shard
+    steps:
+      - name: Confirm integration test shards passed
+        run: echo "All integration test shards passed"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,7 +41,7 @@ jobs:
     secrets: inherit
   node_integration_tests:
     name: node integration tests
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_integration_tests_redis.yml@v2 # WORKFLOW_VERSION
+    uses: ./.github/workflows/parallel_integration_tests.yml
     needs: node_build
     secrets: inherit
   helm_lint:


### PR DESCRIPTION
I had to remove the old parallel integration tests workflow as it used 3rd party code, this caused the tests to take approximately 30 minutes to run.
This reintroduces parallel integration tests with a simple script to split the tests instead of a 3rd party solution.